### PR TITLE
Updating two environment.yml requirements

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - scikit-learn
   - pyyaml
   - pip
-  - r-base=4.4
+  - r-base=4.1
   - r-matrix
   - r-yaml
   - r-devtools
@@ -27,5 +27,4 @@ dependencies:
   - bioconductor-singlecellexperiment
   - r-rcpp
   - bioconductor-biocparallel
-  - pip:
-    - git+https://github.com/constantAmateur/SoupX.git
+  - r-soupx


### PR DESCRIPTION
Looks like r-base 4.4 conflicts with some other requirements.

SoupX isn't installable via pip. Might make more sense to have a setup script that does it, but conda-forge has r-soupx available.